### PR TITLE
feat(auth): edit cookie options

### DIFF
--- a/src/starterProject/WebAPI/Controllers/AuthController.cs
+++ b/src/starterProject/WebAPI/Controllers/AuthController.cs
@@ -116,7 +116,7 @@ public class AuthController : BaseController
 
     private void setRefreshTokenToCookie(RefreshToken refreshToken)
     {
-        CookieOptions cookieOptions = new() { HttpOnly = true, Expires = DateTime.UtcNow.AddDays(7) };
+        CookieOptions cookieOptions = new() { HttpOnly = true, Secure = true, SameSite = SameSiteMode.None, Expires = DateTime.UtcNow.AddDays(7) };
         Response.Cookies.Append(key: "refreshToken", refreshToken.Token, cookieOptions);
     }
 }


### PR DESCRIPTION
While working with Angular client project, the refresh token is not saved as a cookie by the browser because the settings do not allow it. As a result, I added two settings to fix the error I received: "Secure: true" and "SameSite: none".

Cookie settings: Cookie settings per Chrome and Firefox update in 2021:
SameSite=None
Secure

Check this: https://stackoverflow.com/questions/46288437/set-cookies-for-cross-origin-requests