### PR TITLE
Fix: Correct password update logic to use NewPassword

### DIFF
--- a/src/starterProject/Application/Features/Users/Commands/UpdateFromAuth/UpdateUserFromAuthCommand.cs
+++ b/src/starterProject/Application/Features/Users/Commands/UpdateFromAuth/UpdateUserFromAuthCommand.cs
@@ -68,7 +68,7 @@ public class UpdateUserFromAuthCommand : IRequest<UpdatedUserFromAuthResponse>
             if (request.NewPassword != null && !string.IsNullOrWhiteSpace(request.NewPassword))
             {
                 HashingHelper.CreatePasswordHash(
-                    request.Password,
+                    request.NewPassword,
                     passwordHash: out byte[] passwordHash,
                     passwordSalt: out byte[] passwordSalt
                 );


### PR DESCRIPTION
This fix ensures that when a user updates their password, the new password is hashed and stored in the database, rather than rehashing the existing password. Previously, the logic used request.Password instead of request.NewPassword, which caused the hash to change but the password to remain the same.